### PR TITLE
Add hidden attribute to event table

### DIFF
--- a/db/migrate/20150922203156_add_hidden_boolean_to_event.rb
+++ b/db/migrate/20150922203156_add_hidden_boolean_to_event.rb
@@ -1,0 +1,5 @@
+class AddHiddenBooleanToEvent < ActiveRecord::Migration
+  def change
+    add_column :events, :hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150922194637) do
+ActiveRecord::Schema.define(version: 20150922203156) do
 
   create_table "events", force: :cascade do |t|
     t.string   "original_provider"
@@ -22,7 +22,9 @@ ActiveRecord::Schema.define(version: 20150922194637) do
     t.datetime "end_datetime"
     t.string   "location"
     t.string   "rsvp_link"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.boolean  "hidden",            default: false
   end
+
 end


### PR DESCRIPTION
Some events need to be hidden from the API response. This attribute allows this.
